### PR TITLE
Make clusterName optional when hostName is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Scrutineer does _not_ report when items match, we'll presume you're just fine wi
 
 Remote ElasticSearch Hosts
 ==========================
-If you're connecting to a remote host, you need to specify the host name:
+If you're connecting to a remote host, you need to specify the host name instead of the cluster name:
 
     --hostName=my.elastic.search.net
 

--- a/src/main/java/com/aconex/scrutineer/Scrutineer.java
+++ b/src/main/java/com/aconex/scrutineer/Scrutineer.java
@@ -8,6 +8,7 @@ import com.aconex.scrutineer.elasticsearch.IdAndVersionDataWriterFactory;
 import com.aconex.scrutineer.elasticsearch.IteratorFactory;
 import com.aconex.scrutineer.jdbc.JdbcIdAndVersionStream;
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
 import com.fasterxml.sort.DataReaderFactory;
 import com.fasterxml.sort.DataWriterFactory;
 import com.fasterxml.sort.SortConfig;
@@ -57,6 +58,9 @@ public class Scrutineer {
     public void verify() {
         this.idAndVersionFactory = createIdAndVersionFactory();
         this.documentWrapperFactory = createDocumentWrapperFactory();
+        if ((options.clusterName == null) && (options.hostName == null)){
+            throw new ParameterException("Either clusterName or hostName must be provided.");
+        }
         ElasticSearchIdAndVersionStream elasticSearchIdAndVersionStream = createElasticSearchIdAndVersionStream(options);
         JdbcIdAndVersionStream jdbcIdAndVersionStream = createJdbcIdAndVersionStream(options);
         verify(elasticSearchIdAndVersionStream, jdbcIdAndVersionStream, new IdAndVersionStreamVerifier());
@@ -122,7 +126,7 @@ public class Scrutineer {
     }
 
     private Client openClient(ScrutineerCommandLineOptions options) {
-        if (options.hostName.isEmpty()) {
+        if (options.clusterName != null) {
             this.node = new NodeFactory().createNode(options);
             this.client = node.client();
         } else {

--- a/src/main/java/com/aconex/scrutineer/ScrutineerCommandLineOptions.java
+++ b/src/main/java/com/aconex/scrutineer/ScrutineerCommandLineOptions.java
@@ -7,12 +7,12 @@ import com.beust.jcommander.Parameters;
 @Parameters(separators = "=")
 public class ScrutineerCommandLineOptions {
     @Parameter(names = "--hostName", description = "ElasticSearch hostname identifier")
-    public String hostName = "";
+    public String hostName;
 
     @Parameter(names = "--portNumber", description = "ElasticSearch port identifier")
     public int portNumber = 9300;
 
-    @Parameter(names = "--clusterName", description = "ElasticSearch cluster name identifier", required = true)
+    @Parameter(names = "--clusterName", description = "ElasticSearch cluster name identifier")
     public String clusterName;
 
     @Parameter(names = "--indexName", description = "ElasticSearch index name to Verify", required = true)

--- a/src/main/java/com/aconex/scrutineer/TransportClientFactory.java
+++ b/src/main/java/com/aconex/scrutineer/TransportClientFactory.java
@@ -8,14 +8,13 @@ import org.elasticsearch.common.transport.InetSocketTransportAddress;
 public class TransportClientFactory {
 
     public TransportClient createTransportClient(ScrutineerCommandLineOptions commandLineOptions) {
-        TransportClient client = new TransportClient(createSettings(commandLineOptions));
+        TransportClient client = new TransportClient(createSettings());
         client.addTransportAddress(new InetSocketTransportAddress(commandLineOptions.hostName, commandLineOptions.portNumber));
         return client;
     }
 
-    Settings createSettings(ScrutineerCommandLineOptions commandLineOptions) {
+    Settings createSettings() {
         return ImmutableSettings.settingsBuilder()
-                .put("cluster.name", commandLineOptions.clusterName)
                 .build();
     }
 

--- a/src/test/java/com/aconex/scrutineer/ScrutineerTest.java
+++ b/src/test/java/com/aconex/scrutineer/ScrutineerTest.java
@@ -2,7 +2,9 @@ package com.aconex.scrutineer;
 
 import com.aconex.scrutineer.elasticsearch.ElasticSearchIdAndVersionStream;
 import com.aconex.scrutineer.jdbc.JdbcIdAndVersionStream;
+import com.beust.jcommander.ParameterException;
 import com.google.common.base.Function;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -59,14 +61,31 @@ public class ScrutineerTest {
     @Test
     public void testVerify() {
         options.versionField = "version";
+        options.clusterName = "pilipin";
+
         Scrutineer scrutineer = spy(new Scrutineer(options));
         doReturn(elasticSearchIdAndVersionStream).when(scrutineer).createElasticSearchIdAndVersionStream(eq(options));
         doReturn(jdbcIdAndVersionStream).when(scrutineer).createJdbcIdAndVersionStream(options);
         doNothing().when(scrutineer).verify(eq(elasticSearchIdAndVersionStream), eq(jdbcIdAndVersionStream), any(IdAndVersionStreamVerifier.class));
+
         scrutineer.verify();
-
         verify(scrutineer).verify(eq(elasticSearchIdAndVersionStream), eq(jdbcIdAndVersionStream), any(IdAndVersionStreamVerifier.class));
+    }
 
+    @Test
+    public void testVerifyMissingParam() {
+        options.versionField = "version";
+
+        Scrutineer scrutineer = spy(new Scrutineer(options));
+        doReturn(elasticSearchIdAndVersionStream).when(scrutineer).createElasticSearchIdAndVersionStream(eq(options));
+        doReturn(jdbcIdAndVersionStream).when(scrutineer).createJdbcIdAndVersionStream(options);
+        doNothing().when(scrutineer).verify(eq(elasticSearchIdAndVersionStream), eq(jdbcIdAndVersionStream), any(IdAndVersionStreamVerifier.class));
+
+        try {
+            scrutineer.verify();
+            Assert.fail("Parameter exception not raised");
+        } catch (ParameterException err) {
+        }
     }
 
     @Test


### PR DESCRIPTION
Since a cluster name is not needed when using the TransportClient, make it an optional parameter.
